### PR TITLE
Absolute URL for twitter:image

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
   <meta name="description" content="{{ .Page.Description }}">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css">
   {{ template "_internal/opengraph.html" . }}
-  <meta name="twitter:image" content="{{ .Site.BaseURL }}images/logo-twitter-card.png"/>
+  <meta name="twitter:image" content="https://feministclickback.org/images/logo-twitter-card.png"/>
 </head>
 <body class="container">
   <header class="header flex justify-content-flex-end margin-vertical-m">


### PR DESCRIPTION
This PR changes the twitter:image meta tag URL to absolute from relative because Twitter card validator won't recognize it otherwise.