### PR TITLE
Fix bug on header

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
   <meta name="twitter:image" content="https://feministclickback.org/images/logo-twitter-card.png"/>
 </head>
 <body class="container">
-  <header class="header flex justify-content-space-between margin-vertical-m">
+  <header class="header flex {{ if .IsHome }}justify-content-flex-end {{ else }} justify-content-space-between  {{ end }} margin-vertical-m">
     {{ if ne .IsHome true }}
     <div class="">
     <p class="siteTitle primary font-size-xxl margin-xs no-margin-left">


### PR DESCRIPTION
There's one element less on the home page, so justify-content:space-between doesn't make sense. It needs to be flex-end only on the home page.